### PR TITLE
lufact for sparse matrix pivot option error

### DIFF
--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -157,7 +157,7 @@ lufact{T<:AbstractFloat}(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}
     "sparse floating point LU using UMFPACK or lufact(full(A)) for generic ",
     "dense LU.")))
 lufact(A::SparseMatrixCSC) = lufact(float(A))
-lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)
+lufact(A::SparseMatrixCSC, pivot::Type{Val{true}}) = lufact(A)
 
 
 size(F::UmfpackLU) = (F.m, F.n)


### PR DESCRIPTION
base/sparse/umfpack.jl includes the following method definition for lufact

`lufact(A::SparseMatrixCSC, pivot::Type{Val{false}}) = lufact(A)`

This should likely be

`lufact(A::SparseMatrixCSC, pivot::Type{Val{true}}) = lufact(A)`

because in lufact pivoting is on by default.

The error is shown in the following example

```
A = speye(4)
A[1:2,1:2] = [-.01 -200; 200 .001]
F = lufact(A,Val{false})
F[:p]
```
which returns
```
julia> F[:q]
4-element Array{Int64,1}:
 3
 4
 1
 2
```
However it should return
```
julia> F[:q]
4-element Array{Int64,1}:
1
2
3
4
```
because pivoting was turned off.